### PR TITLE
Fix missing first byte on new gen hardware

### DIFF
--- a/zenang.c
+++ b/zenang.c
@@ -100,7 +100,7 @@ const static zena_dev_profile_t zena_mrf24j40 = {
 	0x82,
 	0x01,
 	2,
-	7,
+	6,
 	4
 };
 


### PR DESCRIPTION
fixes github issue #1

This fixes my packets to look better at least.  I get FCS Bad, but I'm not sure if that's a problem or not.  I seem to be getting duplicates though, I see 4 frames in wiresharek for what should have been a single packet.  (But my other sniffer shows 2 frames for what should be a single anyway)
